### PR TITLE
Fix Actor Bugs

### DIFF
--- a/app/models/ResponseTable.scala
+++ b/app/models/ResponseTable.scala
@@ -1,6 +1,6 @@
 package models
 
-import play.api.libs.json.JsString
+import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 import play.api.libs.json.OWrites
 
@@ -10,7 +10,7 @@ case class ResponseTable(
   sequence: Int,
   sql: String,
   mode: Int = 1,
-  data: immutable.Seq[String]
+  data: immutable.Seq[JsValue]
 )
 
 object ResponseTable {

--- a/app/models/ksql/KSQLRow.scala
+++ b/app/models/ksql/KSQLRow.scala
@@ -1,11 +1,12 @@
 package models.ksql
 
+import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
 import scala.collection.immutable
 
-case class KSQLRow(columns: immutable.Seq[String])
+case class KSQLRow(columns: immutable.Seq[JsValue])
 
 object KSQLRow {
   implicit val format: OFormat[KSQLRow] = Json.format[KSQLRow]


### PR DESCRIPTION
This fixes 3 bugs in the actors:

1. The data types should be JsValue so they can return numbers / strings back to javascript.
2. Before, we would send back the message indicating that the limit was reached as an error. Now, we just ignore it and stop sending messages back after that.
3. Actors who no longer should receive messages will stop, helping clean up resources.