### PR TITLE
Add error reporting in case of HTTP failure

### DIFF
--- a/app/actors/ReceiveFromKSQLActor.scala
+++ b/app/actors/ReceiveFromKSQLActor.scala
@@ -25,6 +25,8 @@ class ReceiveFromKSQLActor(out: ActorRef, sequence: Int, sql: String) extends Ac
   implicit val materializer = ActorMaterializer(ActorMaterializerSettings(context.system))
 
   override def receive: Receive = {
+    case Status.Failure(e) =>
+      out ! Json.obj("msg" -> "Error in HTTP Request.", "errors" -> e.toString)
     case HttpResponse(StatusCodes.OK, headers, entity, _) =>
       entity.dataBytes.runForeach { byteString: ByteString =>
         val body = byteString.utf8String


### PR DESCRIPTION
Before, if we could not contact the server, it would just fail silently. Now, it will return an error message.

Test Plan:
1. Set the KSQL_API_SERVER env variable incorrectly.
2. Make sure error is shown.
3. Set it correctly
4. Make sure I don't see error